### PR TITLE
Revert "ci: caching of go modules in test"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,6 @@ jobs:
       - *checkout
       - *setup-go
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151
-        with:
-          install: false
       - name: Test
         run: mise test
       - name: Coverage


### PR DESCRIPTION
This reverts commit 38823f66664c0904adabb6420dde36e52ade0bf9.