### PR TITLE
s5 fixes

### DIFF
--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -30,7 +30,7 @@ type app struct {
 	config      *Config
 	initGateway func(*Config) (tmhi.Gateway, error)
 	newSpinner  func(message string) (spinner, error)
-	confirm     func(msg string, defaultVal bool) (bool, error)
+	confirm     func(ctx context.Context, msg string, defaultVal bool) (bool, error)
 }
 
 func newApp() *app {
@@ -52,15 +52,37 @@ func newPtermSpinner(message string) (spinner, error) {
 	return &spinnerWrapper{spinnerPrinter: sp}, nil
 }
 
-func ptermConfirm(msg string, defaultVal bool) (bool, error) {
-	confirmed, err := pterm.DefaultInteractiveConfirm.
-		WithDefaultValue(defaultVal).
-		Show(msg)
-	if err != nil {
-		return false, fmt.Errorf("confirmation failed: %w", err)
+// ptermConfirm shows an interactive confirmation prompt, returning early with
+// ctx.Err() if ctx is cancelled (e.g. by SIGINT) before the user answers.
+// The prompt itself keeps blocking on stdin in the background since pterm
+// offers no way to interrupt it.
+func ptermConfirm(ctx context.Context, msg string, defaultVal bool) (bool, error) {
+	type confirmResult struct {
+		confirmed bool
+		err       error
 	}
 
-	return confirmed, nil
+	resultCh := make(chan confirmResult, 1)
+
+	go func() {
+		confirmed, err := pterm.DefaultInteractiveConfirm.
+			WithDefaultValue(defaultVal).
+			Show(msg)
+		if err != nil {
+			resultCh <- confirmResult{err: fmt.Errorf("confirmation failed: %w", err)}
+
+			return
+		}
+
+		resultCh <- confirmResult{confirmed: confirmed}
+	}()
+
+	select {
+	case <-ctx.Done():
+		return false, ctx.Err() //nolint:wrapcheck
+	case r := <-resultCh:
+		return r.confirmed, r.err
+	}
 }
 
 // spinnerWrapper wraps pterm.SpinnerPrinter to implement the spinner interface.
@@ -307,6 +329,7 @@ func (a *app) reboot(ctx context.Context, cmd *cli.Command) error {
 
 	if !cmd.Bool(ConfigAutoConfirm) {
 		confirmed, confirmErr := a.confirm(
+			ctx,
 			"Are you sure you want to reboot the gateway?",
 			false,
 		)

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -217,22 +217,29 @@ func (a *app) req(ctx context.Context, cmd *cli.Command) error {
 		return nil
 	}
 
-	loginFirst := cmd.Bool("login")
-
-	if loginFirst {
-		if err := gateway.Login(ctx); err != nil {
-			return fmt.Errorf("login failed: %w", err)
+	if cmd.Bool("login") {
+		if err := runWithFeedback(
+			ctx,
+			a.newSpinner,
+			"Logging in...",
+			gateway.Login,
+			"Successfully logged in",
+		); err != nil {
+			return err
 		}
 	}
 
-	result, err := gateway.Request(ctx, method, path)
-	if err != nil {
-		return fmt.Errorf("request failed: %w", err)
-	}
+	_, err = fetchWithFeedback(
+		ctx,
+		a.newSpinner,
+		fmt.Sprintf("%s %s...", method, path),
+		func(ctx context.Context) (*tmhi.InfoResult, error) {
+			return gateway.Request(ctx, method, path)
+		},
+		displayInfoResult,
+	)
 
-	displayInfoResult(result)
-
-	return nil
+	return err
 }
 
 func (a *app) info(ctx context.Context, _ *cli.Command) error {

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -102,6 +102,9 @@ const (
 	cmdSignal   = "signal"
 )
 
+// ErrReqArgs is returned when req is not given exactly an HTTP method and a path.
+var ErrReqArgs = errors.New("exactly 2 arguments required (HTTP method and path)")
+
 // fetchWithFeedback runs an operation with a spinner, handling success/failure.
 // It starts a spinner with the given message, executes the fetch function,
 // displays the result using the display function, and properly stops the spinner.
@@ -190,7 +193,7 @@ func (a *app) login(ctx context.Context, _ *cli.Command) error {
 func (a *app) req(ctx context.Context, cmd *cli.Command) error {
 	const requiredArgsCount = 2
 	if cmd.NArg() != requiredArgsCount {
-		return cli.Exit("exactly 2 arguments required (HTTP method and path)", 1)
+		return ErrReqArgs
 	}
 
 	gateway, err := a.initGateway(a.config)

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -105,6 +105,9 @@ const (
 // ErrReqArgs is returned when req is not given exactly an HTTP method and a path.
 var ErrReqArgs = errors.New("exactly 2 arguments required (HTTP method and path)")
 
+// ErrReqMethod is returned when req is given an empty HTTP method.
+var ErrReqMethod = errors.New("HTTP method must not be empty")
+
 // fetchWithFeedback runs an operation with a spinner, handling success/failure.
 // It starts a spinner with the given message, executes the fetch function,
 // displays the result using the display function, and properly stops the spinner.
@@ -196,13 +199,17 @@ func (a *app) req(ctx context.Context, cmd *cli.Command) error {
 		return ErrReqArgs
 	}
 
+	method := cmd.Args().Get(0)
+	path := cmd.Args().Get(1)
+
+	if method == "" {
+		return ErrReqMethod
+	}
+
 	gateway, err := a.initGateway(a.config)
 	if err != nil {
 		return err
 	}
-
-	method := cmd.Args().Get(0)
-	path := cmd.Args().Get(1)
 
 	if a.config.DryRun {
 		pterm.Info.Printfln("Dry run - would send %s %s request", method, path)

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -200,6 +200,13 @@ func (a *app) req(ctx context.Context, cmd *cli.Command) error {
 
 	method := cmd.Args().Get(0)
 	path := cmd.Args().Get(1)
+
+	if a.config.DryRun {
+		pterm.Info.Printfln("Dry run - would send %s %s request", method, path)
+
+		return nil
+	}
+
 	loginFirst := cmd.Bool("login")
 
 	if loginFirst {

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -284,6 +284,25 @@ func TestReq_Command(t *testing.T) {
 		assert.Contains(t, err.Error(), "exactly 2 arguments required")
 	})
 
+	t.Run("dry-run does not perform the request", func(t *testing.T) {
+		mg := &mockGateway{}
+		a := newTestApp(mg)
+		a.config = &Config{DryRun: true}
+
+		reqCmd := &cli.Command{
+			Name:   cmdReq,
+			Action: a.req,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: cmdLogin, Value: false},
+			},
+		}
+
+		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
+		require.NoError(t, err)
+		assert.False(t, mg.requestCalled, "request should be skipped in dry-run mode")
+		assert.False(t, mg.loginCalled, "login should be skipped in dry-run mode")
+	})
+
 	t.Run("performs request", func(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -274,14 +274,20 @@ func TestReq_Command(t *testing.T) {
 			},
 		}
 
+		exited := false
 		origExiter := cli.OsExiter
-		cli.OsExiter = func(_ int) {}
+		cli.OsExiter = func(_ int) { exited = true }
 
 		t.Cleanup(func() { cli.OsExiter = origExiter })
 
 		err := reqCmd.Run(t.Context(), []string{appName, cmdReq})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "exactly 2 arguments required")
+		assert.False(
+			t,
+			exited,
+			"argument validation should return a normal error, not exit the process",
+		)
 	})
 
 	t.Run("dry-run does not perform the request", func(t *testing.T) {

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -290,6 +290,24 @@ func TestReq_Command(t *testing.T) {
 		)
 	})
 
+	t.Run("empty method is rejected", func(t *testing.T) {
+		mg := &mockGateway{}
+		a := newTestApp(mg)
+
+		reqCmd := &cli.Command{
+			Name:   cmdReq,
+			Action: a.req,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: cmdLogin, Value: false},
+			},
+		}
+
+		err := reqCmd.Run(t.Context(), []string{cmdReq, "", testReqPath})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "HTTP method must not be empty")
+		assert.False(t, mg.requestCalled, "request should not be performed with an empty method")
+	})
+
 	t.Run("dry-run does not perform the request", func(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -81,17 +81,29 @@ func (m *mockGateway) Signal(context.Context) (*tmhi.SignalResult, error) {
 	return &tmhi.SignalResult{}, nil
 }
 
-func newRebootCmd(dry bool) *cli.Command {
+func newRebootCmd(dryRun, autoConfirm bool) *cli.Command {
 	return &cli.Command{
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  ConfigDryRun,
-				Value: dry,
+				Value: dryRun,
 			},
 			&cli.BoolFlag{
 				Name:  ConfigAutoConfirm,
-				Value: true,
+				Value: autoConfirm,
 			},
+		},
+	}
+}
+
+// newReqCmd builds the req command as wired by cmd_builder.go, so req tests
+// exercise the same flag/action wiring the real CLI uses.
+func newReqCmd(a *app) *cli.Command {
+	return &cli.Command{
+		Name:   cmdReq,
+		Action: a.req,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: cmdLogin, Value: false},
 		},
 	}
 }
@@ -175,7 +187,7 @@ func TestReboot_DryRunFlagAndFailure(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
 		a.config = &Config{DryRun: true}
-		cmd := newRebootCmd(true)
+		cmd := newRebootCmd(true, true)
 		err := a.reboot(t.Context(), cmd)
 		require.NoError(t, err)
 		assert.False(t, mg.rebootCalled)
@@ -185,7 +197,7 @@ func TestReboot_DryRunFlagAndFailure(t *testing.T) {
 		mg := &mockGateway{rebootErr: errors.New("reboot boom")}
 		a := newTestApp(mg)
 		a.config = &Config{DryRun: false}
-		cmd := newRebootCmd(false)
+		cmd := newRebootCmd(false, true)
 		err := a.reboot(t.Context(), cmd)
 		require.Error(t, err)
 		assert.True(t, mg.rebootCalled)
@@ -212,12 +224,7 @@ func TestReboot_ConfirmationDefaultsToNo(t *testing.T) {
 		a.confirm = func(_ context.Context, _ string, _ bool) (bool, error) {
 			return false, errors.New("prompt broken")
 		}
-		cmd := &cli.Command{
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: ConfigDryRun, Value: false},
-				&cli.BoolFlag{Name: ConfigAutoConfirm, Value: false},
-			},
-		}
+		cmd := newRebootCmd(false, false)
 
 		err := a.reboot(t.Context(), cmd)
 		require.Error(t, err)
@@ -233,12 +240,7 @@ func TestReboot_ConfirmationDefaultsToNo(t *testing.T) {
 
 			return false, ctx.Err()
 		}
-		cmd := &cli.Command{
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: ConfigDryRun, Value: false},
-				&cli.BoolFlag{Name: ConfigAutoConfirm, Value: false},
-			},
-		}
+		cmd := newRebootCmd(false, false)
 
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
@@ -252,12 +254,7 @@ func TestReboot_ConfirmationDefaultsToNo(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
 		a.config = &Config{DryRun: false}
-		cmd := &cli.Command{
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: ConfigDryRun, Value: false},
-				&cli.BoolFlag{Name: ConfigAutoConfirm, Value: true},
-			},
-		}
+		cmd := newRebootCmd(false, true)
 
 		err := a.reboot(t.Context(), cmd)
 		require.NoError(t, err)
@@ -274,12 +271,7 @@ func testRebootConfirm(t *testing.T, confirmResult bool, expectCalled bool, msg 
 	a.confirm = func(_ context.Context, _ string, _ bool) (bool, error) {
 		return confirmResult, nil
 	}
-	cmd := &cli.Command{
-		Flags: []cli.Flag{
-			&cli.BoolFlag{Name: ConfigDryRun, Value: false},
-			&cli.BoolFlag{Name: ConfigAutoConfirm, Value: false},
-		},
-	}
+	cmd := newRebootCmd(false, false)
 
 	err := a.reboot(t.Context(), cmd)
 	require.NoError(t, err)
@@ -291,13 +283,7 @@ func TestReq_Command(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
 
-		reqCmd := &cli.Command{
-			Name:   "req",
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: "login", Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		exited := false
 		origExiter := cli.OsExiter
@@ -318,14 +304,7 @@ func TestReq_Command(t *testing.T) {
 	t.Run("empty method is rejected", func(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, "", testReqPath})
 		require.Error(t, err)
@@ -337,14 +316,7 @@ func TestReq_Command(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
 		a.config = &Config{DryRun: true}
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
 		require.NoError(t, err)
@@ -355,14 +327,7 @@ func TestReq_Command(t *testing.T) {
 	t.Run("performs request", func(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
 		require.NoError(t, err)
@@ -373,14 +338,7 @@ func TestReq_Command(t *testing.T) {
 	t.Run("logs in first with --login", func(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqLogin, testReqMethod, testReqPath})
 		require.NoError(t, err)
@@ -391,14 +349,7 @@ func TestReq_Command(t *testing.T) {
 	t.Run("login failure aborts request", func(t *testing.T) {
 		mg := &mockGateway{loginErr: errors.New("bad credentials")}
 		a := newTestApp(mg)
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqLogin, testReqMethod, testReqPath})
 		require.Error(t, err)
@@ -409,14 +360,7 @@ func TestReq_Command(t *testing.T) {
 	t.Run("request failure returns error", func(t *testing.T) {
 		mg := &mockGateway{requestErr: errors.New("gateway timeout")}
 		a := newTestApp(mg)
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
 		require.Error(t, err)
@@ -428,55 +372,45 @@ func TestReq_Command(t *testing.T) {
 		mg := &mockGateway{loginErr: errors.New("bad credentials")}
 		a := newTestApp(mg)
 
-		var spinners []*trackingSpinner
-
-		a.newSpinner = func(_ string) (spinner, error) {
-			s := &trackingSpinner{}
-			spinners = append(spinners, s)
-
-			return s, nil
-		}
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		factory, spinners := newSpyingSpinnerFactory()
+		a.newSpinner = factory
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqLogin, testReqMethod, testReqPath})
 		require.Error(t, err)
-		require.Len(t, spinners, 1, "only the login spinner should have been created")
-		assert.True(t, spinners[0].failCalled, "login failure should surface spinner feedback")
+		require.Len(t, *spinners, 1, "only the login spinner should have been created")
+		assert.True(t, (*spinners)[0].failCalled, "login failure should surface spinner feedback")
 	})
 
 	t.Run("request failure shows spinner feedback", func(t *testing.T) {
 		mg := &mockGateway{requestErr: errors.New("gateway timeout")}
 		a := newTestApp(mg)
 
-		var spinners []*trackingSpinner
-
-		a.newSpinner = func(_ string) (spinner, error) {
-			s := &trackingSpinner{}
-			spinners = append(spinners, s)
-
-			return s, nil
-		}
-
-		reqCmd := &cli.Command{
-			Name:   cmdReq,
-			Action: a.req,
-			Flags: []cli.Flag{
-				&cli.BoolFlag{Name: cmdLogin, Value: false},
-			},
-		}
+		factory, spinners := newSpyingSpinnerFactory()
+		a.newSpinner = factory
+		reqCmd := newReqCmd(a)
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
 		require.Error(t, err)
-		require.Len(t, spinners, 1, "only the request spinner should have been created")
-		assert.True(t, spinners[0].failCalled, "request failure should surface spinner feedback")
+		require.Len(t, *spinners, 1, "only the request spinner should have been created")
+		assert.True(t, (*spinners)[0].failCalled, "request failure should surface spinner feedback")
 	})
+}
+
+// newSpyingSpinnerFactory returns a spinner factory and a pointer to the
+// slice of trackingSpinners it creates, so tests can assert on spinner
+// feedback without wiring up their own closures.
+func newSpyingSpinnerFactory() (func(string) (spinner, error), *[]*trackingSpinner) {
+	var spinners []*trackingSpinner
+
+	factory := func(_ string) (spinner, error) {
+		s := &trackingSpinner{}
+		spinners = append(spinners, s)
+
+		return s, nil
+	}
+
+	return factory, &spinners
 }
 
 func TestInitGateway(t *testing.T) {

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -209,7 +209,7 @@ func TestReboot_ConfirmationDefaultsToNo(t *testing.T) {
 		mg := &mockGateway{}
 		a := newTestApp(mg)
 		a.config = &Config{DryRun: false}
-		a.confirm = func(_ string, _ bool) (bool, error) {
+		a.confirm = func(_ context.Context, _ string, _ bool) (bool, error) {
 			return false, errors.New("prompt broken")
 		}
 		cmd := &cli.Command{
@@ -222,6 +222,30 @@ func TestReboot_ConfirmationDefaultsToNo(t *testing.T) {
 		err := a.reboot(t.Context(), cmd)
 		require.Error(t, err)
 		assert.False(t, mg.rebootCalled, "reboot should not proceed on prompt failure")
+	})
+
+	t.Run("cancelled context aborts reboot instead of hanging", func(t *testing.T) {
+		mg := &mockGateway{}
+		a := newTestApp(mg)
+		a.config = &Config{DryRun: false}
+		a.confirm = func(ctx context.Context, _ string, _ bool) (bool, error) {
+			<-ctx.Done()
+
+			return false, ctx.Err()
+		}
+		cmd := &cli.Command{
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: ConfigDryRun, Value: false},
+				&cli.BoolFlag{Name: ConfigAutoConfirm, Value: false},
+			},
+		}
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		err := a.reboot(ctx, cmd)
+		require.Error(t, err)
+		assert.False(t, mg.rebootCalled, "reboot should not proceed once the context is cancelled")
 	})
 
 	t.Run("auto confirm skips prompt", func(t *testing.T) {
@@ -247,7 +271,7 @@ func testRebootConfirm(t *testing.T, confirmResult bool, expectCalled bool, msg 
 	mg := &mockGateway{}
 	a := newTestApp(mg)
 	a.config = &Config{DryRun: false}
-	a.confirm = func(_ string, _ bool) (bool, error) {
+	a.confirm = func(_ context.Context, _ string, _ bool) (bool, error) {
 		return confirmResult, nil
 	}
 	cmd := &cli.Command{

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -15,6 +15,7 @@ import (
 const (
 	testReqMethod = "GET"
 	testReqPath   = "/test"
+	testReqLogin  = "--login"
 )
 
 type mockGateway struct {
@@ -357,7 +358,7 @@ func TestReq_Command(t *testing.T) {
 			},
 		}
 
-		err := reqCmd.Run(t.Context(), []string{cmdReq, "--login", testReqMethod, testReqPath})
+		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqLogin, testReqMethod, testReqPath})
 		require.NoError(t, err)
 		assert.True(t, mg.loginCalled, "login should be performed first")
 		assert.True(t, mg.requestCalled, "request should be performed")
@@ -375,9 +376,9 @@ func TestReq_Command(t *testing.T) {
 			},
 		}
 
-		err := reqCmd.Run(t.Context(), []string{cmdReq, "--login", testReqMethod, testReqPath})
+		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqLogin, testReqMethod, testReqPath})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "login failed")
+		assert.Contains(t, err.Error(), "bad credentials")
 		assert.False(t, mg.requestCalled, "request should not be performed")
 	})
 
@@ -395,9 +396,62 @@ func TestReq_Command(t *testing.T) {
 
 		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "request failed")
 		assert.Contains(t, err.Error(), "gateway timeout")
 		assert.True(t, mg.requestCalled, "request should have been attempted")
+	})
+
+	t.Run("login failure shows spinner feedback", func(t *testing.T) {
+		mg := &mockGateway{loginErr: errors.New("bad credentials")}
+		a := newTestApp(mg)
+
+		var spinners []*trackingSpinner
+
+		a.newSpinner = func(_ string) (spinner, error) {
+			s := &trackingSpinner{}
+			spinners = append(spinners, s)
+
+			return s, nil
+		}
+
+		reqCmd := &cli.Command{
+			Name:   cmdReq,
+			Action: a.req,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: cmdLogin, Value: false},
+			},
+		}
+
+		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqLogin, testReqMethod, testReqPath})
+		require.Error(t, err)
+		require.Len(t, spinners, 1, "only the login spinner should have been created")
+		assert.True(t, spinners[0].failCalled, "login failure should surface spinner feedback")
+	})
+
+	t.Run("request failure shows spinner feedback", func(t *testing.T) {
+		mg := &mockGateway{requestErr: errors.New("gateway timeout")}
+		a := newTestApp(mg)
+
+		var spinners []*trackingSpinner
+
+		a.newSpinner = func(_ string) (spinner, error) {
+			s := &trackingSpinner{}
+			spinners = append(spinners, s)
+
+			return s, nil
+		}
+
+		reqCmd := &cli.Command{
+			Name:   cmdReq,
+			Action: a.req,
+			Flags: []cli.Flag{
+				&cli.BoolFlag{Name: cmdLogin, Value: false},
+			},
+		}
+
+		err := reqCmd.Run(t.Context(), []string{cmdReq, testReqMethod, testReqPath})
+		require.Error(t, err)
+		require.Len(t, spinners, 1, "only the request spinner should have been created")
+		assert.True(t, spinners[0].failCalled, "request failure should surface spinner feedback")
 	})
 }
 

--- a/internal/cmd_test.go
+++ b/internal/cmd_test.go
@@ -150,6 +150,15 @@ func TestFetchWithFeedback_SpinnerError(t *testing.T) {
 	assert.Contains(t, err.Error(), "spinner failed")
 }
 
+func TestPtermConfirm_ContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	confirmed, err := ptermConfirm(ctx, "irrelevant", false)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.False(t, confirmed)
+}
+
 func TestDefaultConfigPath(t *testing.T) {
 	path := defaultConfigPath()
 	require.NotEmpty(t, path)

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -1,6 +1,7 @@
 package internal
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -30,7 +31,7 @@ func (s *trackingSpinner) Success(_ ...any) { s.successCalled = true }
 func newTestApp(gw tmhi.Gateway) *app {
 	a := newApp()
 	a.newSpinner = func(_ string) (spinner, error) { return &mockSpinner{}, nil }
-	a.confirm = func(_ string, defaultVal bool) (bool, error) { return defaultVal, nil }
+	a.confirm = func(_ context.Context, _ string, defaultVal bool) (bool, error) { return defaultVal, nil }
 	a.initGateway = func(_ *Config) (tmhi.Gateway, error) { return gw, nil }
 
 	return a

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -13,6 +13,17 @@ func (*mockSpinner) Fail(_ ...any) {}
 
 func (*mockSpinner) Success(_ ...any) {}
 
+// trackingSpinner records whether Fail/Success feedback was shown, so tests
+// can assert a command surfaced spinner feedback on failure.
+type trackingSpinner struct {
+	failCalled    bool
+	successCalled bool
+}
+
+func (s *trackingSpinner) Fail(_ ...any) { s.failCalled = true }
+
+func (s *trackingSpinner) Success(_ ...any) { s.successCalled = true }
+
 // newTestApp returns an app wired with test doubles: a no-op spinner (the
 // real one spawns goroutines that race in tests), a confirm stub returning
 // its default, and a gateway factory returning gw.

--- a/internal/ui.go
+++ b/internal/ui.go
@@ -43,6 +43,10 @@ func displaySignalResult(result *tmhi.SignalResult) {
 	if result.Generic != (tmhi.GenericSignalInfo{}) {
 		displayGenericSignalInfo(result)
 	}
+
+	if result.FourG == nil && result.FiveG == nil && result.Generic == (tmhi.GenericSignalInfo{}) {
+		pterm.Warning.Println("No signal information available")
+	}
 }
 
 const signalMetricsCount = 6

--- a/internal/ui_test.go
+++ b/internal/ui_test.go
@@ -148,6 +148,20 @@ func TestDisplaySignalResult(t *testing.T) {
 	})
 }
 
+func TestDisplaySignalResult_EmptyResultWarns(t *testing.T) {
+	pterm.DisableStyling()
+	t.Cleanup(pterm.EnableStyling)
+
+	var buf bytes.Buffer
+
+	pterm.SetDefaultOutput(&buf)
+	t.Cleanup(func() { pterm.SetDefaultOutput(os.Stdout) })
+
+	displaySignalResult(&tmhi.SignalResult{})
+
+	assert.Contains(t, buf.String(), "No signal information available")
+}
+
 func TestDisplayInfoResult(t *testing.T) {
 	pterm.DisableStyling()
 	t.Cleanup(pterm.EnableStyling)

--- a/internal/ui_test.go
+++ b/internal/ui_test.go
@@ -16,6 +16,22 @@ const (
 	testRegState = "registered"
 )
 
+// captureDefaultOutput disables pterm styling and redirects its default
+// output to a buffer for the duration of the test, returning that buffer.
+func captureDefaultOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+
+	pterm.DisableStyling()
+	t.Cleanup(pterm.EnableStyling)
+
+	var buf bytes.Buffer
+
+	pterm.SetDefaultOutput(&buf)
+	t.Cleanup(func() { pterm.SetDefaultOutput(os.Stdout) })
+
+	return &buf
+}
+
 func TestDisplayStatusResult(t *testing.T) {
 	pterm.DisableStyling()
 	t.Cleanup(pterm.EnableStyling)
@@ -149,13 +165,7 @@ func TestDisplaySignalResult(t *testing.T) {
 }
 
 func TestDisplaySignalResult_EmptyResultWarns(t *testing.T) {
-	pterm.DisableStyling()
-	t.Cleanup(pterm.EnableStyling)
-
-	var buf bytes.Buffer
-
-	pterm.SetDefaultOutput(&buf)
-	t.Cleanup(func() { pterm.SetDefaultOutput(os.Stdout) })
+	buf := captureDefaultOutput(t)
 
 	displaySignalResult(&tmhi.SignalResult{})
 
@@ -172,13 +182,7 @@ func TestDisplayInfoResult(t *testing.T) {
 }
 
 func TestDisplaySignalMetrics_Output(t *testing.T) {
-	pterm.DisableStyling()
-	t.Cleanup(pterm.EnableStyling)
-
-	var buf bytes.Buffer
-
-	pterm.SetDefaultOutput(&buf)
-	t.Cleanup(func() { pterm.SetDefaultOutput(os.Stdout) })
+	buf := captureDefaultOutput(t)
 
 	displaySignalMetrics("Test Signal", &tmhi.SignalData{
 		Bars:  3,


### PR DESCRIPTION
- **fix(cli): honor --dry-run in the req command**
- **fix(cli): return req argument errors normally instead of exiting**
- **fix(cli): reject an empty HTTP method in req**
- **fix(cli): give req login/request failures spinner feedback**
- **fix(cli): warn when signal returns no data**
- **fix(cli): let SIGINT interrupt the reboot confirmation prompt**
- **test(cli): dedupe req/reboot command fixtures and pterm capture setup**
