### PR TITLE
test(cli): close audit gaps in goroutine leak detection and coverage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/urfave/cli-validation v0.0.0-20230629031421-92802a7fd6e9
 	github.com/urfave/cli/v3 v3.10.0
 	github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04
+	go.uber.org/goleak v1.3.0
 	golang.org/x/term v0.44.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -81,6 +81,8 @@ github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJu
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04 h1:qXafrlZL1WsJW5OokjraLLRURHiw0OzKHD/RNdspp4w=
 github.com/zenizh/go-capturer v0.0.0-20211219060012-52ea6c8fed04/go.mod h1:FiwNQxz6hGoNFBC4nIx+CxZhI3nne5RmIOlT/MXcSD4=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZtfTpbJLDr/lwfgO53E=

--- a/internal/cmd.go
+++ b/internal/cmd.go
@@ -120,6 +120,7 @@ const (
 	autoValue   = "auto"
 	cmdLogin    = "login"
 	cmdReq      = "req"
+	cmdInfo     = "info"
 	cmdStatus   = "status"
 	cmdSignal   = "signal"
 )

--- a/internal/cmd_builder.go
+++ b/internal/cmd_builder.go
@@ -50,7 +50,7 @@ func (a *app) commands() []*cli.Command {
 			Action: a.reboot,
 		},
 		{
-			Name:   "info",
+			Name:   cmdInfo,
 			Usage:  "Get gateway information",
 			Action: a.info,
 		},

--- a/internal/cmd_handlers_test.go
+++ b/internal/cmd_handlers_test.go
@@ -126,7 +126,7 @@ func TestHandlerSuccessAndFailure(t *testing.T) {
 			errChecks: []string{"login failed"},
 		},
 		{
-			name:    "info",
+			name:    cmdInfo,
 			handler: func(a *app) cli.ActionFunc { return a.info },
 			called:  func(mg *mockGateway) bool { return mg.infoCalled },
 			setupFail: func(mg *mockGateway) {

--- a/internal/cmd_test.go
+++ b/internal/cmd_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli/v3"
 	capturer "github.com/zenizh/go-capturer"
+	"go.uber.org/goleak"
 )
 
 func TestCaptureOutput(t *testing.T) {
@@ -157,6 +158,10 @@ func TestPtermConfirm_ContextCancelled(t *testing.T) {
 	confirmed, err := ptermConfirm(ctx, "irrelevant", false)
 	require.ErrorIs(t, err, context.Canceled)
 	assert.False(t, confirmed)
+
+	// The background goroutine keeps blocking on the keyboard listener (see
+	// ptermConfirmLeakIgnores); assert nothing beyond that known leak remains.
+	assert.NoError(t, goleak.Find(ptermConfirmLeakIgnores()...))
 }
 
 func TestDefaultConfigPath(t *testing.T) {
@@ -186,7 +191,7 @@ func TestBuildCommands(t *testing.T) {
 	require.Len(t, commands, 6)
 	require.Equal(t, "login", commands[0].Name)
 	require.Equal(t, "reboot", commands[1].Name)
-	require.Equal(t, "info", commands[2].Name)
+	require.Equal(t, cmdInfo, commands[2].Name)
 	require.Equal(t, "status", commands[3].Name)
 	require.Equal(t, "signal", commands[4].Name)
 	require.Equal(t, "req", commands[5].Name)
@@ -405,12 +410,43 @@ func TestQuietFlagAction(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestInitGateway_Success(t *testing.T) {
+	cfg := &Config{
+		Model:    ARCADYAN,
+		IP:       "192.168.12.1",
+		Username: "admin",
+		Password: "password",
+		Timeout:  DefaultTimeout,
+		Retries:  1,
+	}
+
+	gateway, err := initGateway(cfg)
+	require.NoError(t, err)
+	assert.NotNil(t, gateway)
+}
+
+func TestInitGateway_ValidationError(t *testing.T) {
+	gateway, err := initGateway(&Config{})
+	require.Error(t, err)
+	assert.Nil(t, gateway)
+}
+
+func TestInfo_FetchError(t *testing.T) {
+	expectedErr := errors.New("info fetch failed")
+	a := newTestApp(&mockGateway{infoErr: expectedErr})
+
+	err := a.info(t.Context(), &cli.Command{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "info fetch failed")
+}
+
 func TestGatewayInitErrors(t *testing.T) {
 	tests := []struct {
 		name    string
 		handler func(*app) cli.ActionFunc
 	}{
 		{cmdLogin, func(a *app) cli.ActionFunc { return a.login }},
+		{cmdInfo, func(a *app) cli.ActionFunc { return a.info }},
 		{cmdStatus, func(a *app) cli.ActionFunc { return a.status }},
 		{cmdSignal, func(a *app) cli.ActionFunc { return a.signal }},
 		{"reboot", func(a *app) cli.ActionFunc { return a.reboot }},

--- a/internal/main_test.go
+++ b/internal/main_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	tmhi "github.com/hugoh/tmhi-gateway/v2"
+	"go.uber.org/goleak"
 )
 
 type mockSpinner struct{}
@@ -37,23 +38,29 @@ func newTestApp(gw tmhi.Gateway) *app {
 	return a
 }
 
+// ptermConfirmLeakIgnores returns goleak options for ptermConfirm's
+// background goroutine (internal/cmd.go), which keeps reading stdin after
+// ctx cancellation since pterm offers no way to interrupt it; it blocks
+// forever on the underlying keyboard listener rather than exiting, so it's
+// ignored here rather than treated as a leak.
+func ptermConfirmLeakIgnores() []goleak.Option {
+	return []goleak.Option{
+		goleak.IgnoreTopFunction("atomicgo.dev/keyboard.Listen"),
+		goleak.IgnoreTopFunction("atomicgo.dev/keyboard.Listen.func3"),
+	}
+}
+
+// TestMain sets a temp HOME for the test binary (avoiding the real user's
+// config) and wires up goleak so any goroutine leak fails the run.
+// goleak.VerifyTestMain exits the process itself, so the temp dir is best
+// left for the OS to reclaim rather than cleaned up via defer here.
 func TestMain(m *testing.M) {
-	// Use a temp directory as HOME to avoid reading user's config
 	dir, err := os.MkdirTemp("", "tmhi-test-home")
 	if err != nil {
 		os.Exit(1)
 	}
 
-	origHome := os.Getenv("HOME")
 	_ = os.Setenv("HOME", dir) // skipcq: GO-W1032
 
-	code := m.Run()
-
-	_ = os.Setenv("HOME", origHome) // skipcq: GO-W1032
-
-	if err := os.RemoveAll(dir); err != nil && code == 0 {
-		code = 1
-	}
-
-	os.Exit(code)
+	goleak.VerifyTestMain(m, ptermConfirmLeakIgnores()...)
 }


### PR DESCRIPTION
Wire up goleak.VerifyTestMain to catch unintended goroutine leaks,
ignoring the known-leaky ptermConfirm background goroutine (blocked
forever on the keyboard listener since pterm can't be interrupted),
and assert in TestPtermConfirm_ContextCancelled that no other leak
occurs. Restructure TestMain so HOME/tempdir setup happens before
goleak takes over process exit.

Also add tests for previously uncovered paths: initGateway's success
path, info's gateway-init-error and fetch-error paths.
