### PR TITLE
chore: update from go-tools template

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 528783e
+_commit: 5fa8d23
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - main.go

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@528783e852e2e696f210acc4441b4c5983d396b0
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@528783e852e2e696f210acc4441b4c5983d396b0
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@528783e852e2e696f210acc4441b4c5983d396b0
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,9 +12,9 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@528783e852e2e696f210acc4441b4c5983d396b0
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@5fa8d238ac1723b18ede32c5dfe03a6ae21e20f2
     permissions:
       contents: write
       pull-requests: write
     secrets:
-      gh_token: ${{ secrets.GITHUB_TOKEN }}
+      gh_token: ${{ secrets.TEMPLATE_UPDATE_TOKEN }}


### PR DESCRIPTION
Bumps the pinned go-tools workflow SHA and switches
template-update.yml's push token to TEMPLATE_UPDATE_TOKEN (a PAT
with Workflows write access) — the automatic GITHUB_TOKEN can never
push changes to .github/workflows/*.yml, which was causing every
dispatched template-update run to fail.
