### PR TITLE
chore: update from go-tools template (b341f90)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 7e56587
+_commit: b341f90
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - main.go
@@ -19,6 +19,7 @@ golangci_test_exclude_linters:
 - err113
 - funlen
 - varnamelen
+goreleaser_before_hooks: []
 goreleaser_version_pkg: main
 has_fuzz: false
 has_gen: false
@@ -28,6 +29,7 @@ has_test_int: true
 hk_has_golangci_step: true
 hk_has_goreleaser_step: false
 hk_prepush_with_go_ci: false
+nfpm_extra_contents: []
 project_description: CLI for managing T-Mobile Home Internet gateway and signal monitoring
 project_name: tmhi-cli
 test_int_cmd: test ! -d internal || gotestsum -- -race -tags=integration ./internal/...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@7e56587508c85b246ffa7d9c8f9614593b811f02
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@b341f90bfa8e044846e0346cebeca6feb3b3f308
     permissions:
       contents: write
       pull-requests: write

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
 version: 2
+
 builds:
   - env:
       - CGO_ENABLED=0


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@b341f90. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.