### PR TITLE
chore: update from go-tools template (v1.0.0)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -35,3 +35,4 @@ test_int_cmd: test ! -d internal || gotestsum -- -race -tags=integration ./inter
 testcoverage_excludes:
 - main\.go$
 testcoverage_overrides: []
+


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@v1.0.0. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.