### PR TITLE
chore: update from go-tools template (v1.1.0)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v1.0.0
+_commit: v1.1.0
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - main.go
@@ -35,3 +35,4 @@ test_int_cmd: test ! -d internal || gotestsum -- -race -tags=integration ./inter
 testcoverage_excludes:
 - main\.go$
 testcoverage_overrides: []
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,20 @@ permissions: {}
 
 jobs:
   hk:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-hk.yml@bc7c629e60bd78a6b10749054c481382cffedacf # v1.0.0
+=======
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+>>>>>>> after updating
     permissions:
       contents: read
 
   goci:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-ci.yml@bc7c629e60bd78a6b10749054c481382cffedacf # v1.0.0
+=======
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+>>>>>>> after updating
     permissions:
       contents: read
     secrets:
@@ -24,7 +32,11 @@ jobs:
 
   release:
     needs: [hk, goci]
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-release.yml@bc7c629e60bd78a6b10749054c481382cffedacf # v1.0.0
+=======
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+>>>>>>> after updating
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -12,7 +12,11 @@ permissions: {}
 
 jobs:
   update:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-template-update.yml@bc7c629e60bd78a6b10749054c481382cffedacf # v1.0.0
+=======
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@310e3de60bb4ac5daaff871d3b34ab6cc1f7562b
+>>>>>>> after updating
     permissions:
       contents: write
       pull-requests: write

--- a/hk.pkl
+++ b/hk.pkl
@@ -28,7 +28,13 @@ local linters = new Mapping<String, Step> {
   ["golangci-lint"] = (Builtins.golangci_lint) {
     profiles = List("!ci")
   }
+<<<<<<< before updating
   ["gomod-tidy"] = Builtins.gomod_tidy
+=======
+  ["gomod-tidy"] = (Builtins.gomod_tidy) {
+    profiles = List("!ci")
+  }
+>>>>>>> after updating
   ["shellcheck"] = Builtins.shellcheck
   ["conventional-commit"] {
     check = "cog check --from-latest-tag"


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@v1.1.0. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.