### PR TITLE
fix(ci): repin go-tools reusable workflows to a reachable commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@f96c093130d5b6850c2fd66ce55818de447afbe9
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
     permissions:
       contents: read
 
   goci:
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@f96c093130d5b6850c2fd66ce55818de447afbe9
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
     permissions:
       contents: read
     secrets:
@@ -24,7 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@f96c093130d5b6850c2fd66ce55818de447afbe9
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -10,7 +10,7 @@ permissions: {}
 
 jobs:
   update:
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@f96c093130d5b6850c2fd66ce55818de447afbe9
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- All self-referential `hugoh/go-tools/...@f96c093` pins in this repo's workflows point at a commit that just became unreachable on go-tools (an orphaned changelog-bump commit created by a bug in go-tools' release pipeline, now fixed upstream: hugoh/go-tools#5).
- Repinned to go-tools' current `main` HEAD (`f0c60ec582a8ce90080980a4fb79409a0d195491`).
- This was actively breaking `template-update.yml` and would have broken `ci.yml`'s reusable-workflow jobs the same way.

## Test plan
- [x] Pre-push hooks (`mise ci`, hk checks) ran locally — passed
- [ ] Confirm CI workflows resolve and run on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)