### PR TITLE
chore: update from go-tools template (v1.2.2)

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: v1.2.0
+_commit: v1.2.2
 _src_path: gh:hugoh/go-tools
 codecov_ignore:
 - main.go
@@ -35,3 +35,4 @@ test_int_cmd: test ! -d internal || gotestsum -- -race -tags=integration ./inter
 testcoverage_excludes:
 - main\.go$
 testcoverage_overrides: []
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,20 +11,12 @@ permissions: {}
 
 jobs:
   hk:
-<<<<<<< before updating
-    uses: hugoh/go-tools/.github/workflows/go-hk.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
-=======
     uses: hugoh/go-tools/.github/workflows/go-hk.yml@663b58989a6fff490d674991439ebb69f15e4b63
->>>>>>> after updating
     permissions:
       contents: read
 
   goci:
-<<<<<<< before updating
-    uses: hugoh/go-tools/.github/workflows/go-ci.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
-=======
     uses: hugoh/go-tools/.github/workflows/go-ci.yml@663b58989a6fff490d674991439ebb69f15e4b63
->>>>>>> after updating
     permissions:
       contents: read
     secrets:
@@ -32,11 +24,7 @@ jobs:
 
   release:
     needs: [hk, goci]
-<<<<<<< before updating
-    uses: hugoh/go-tools/.github/workflows/go-release.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
-=======
     uses: hugoh/go-tools/.github/workflows/go-release.yml@663b58989a6fff490d674991439ebb69f15e4b63
->>>>>>> after updating
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,20 @@ permissions: {}
 
 jobs:
   hk:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-hk.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
+=======
+    uses: hugoh/go-tools/.github/workflows/go-hk.yml@663b58989a6fff490d674991439ebb69f15e4b63
+>>>>>>> after updating
     permissions:
       contents: read
 
   goci:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-ci.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
+=======
+    uses: hugoh/go-tools/.github/workflows/go-ci.yml@663b58989a6fff490d674991439ebb69f15e4b63
+>>>>>>> after updating
     permissions:
       contents: read
     secrets:
@@ -24,7 +32,11 @@ jobs:
 
   release:
     needs: [hk, goci]
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-release.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
+=======
+    uses: hugoh/go-tools/.github/workflows/go-release.yml@663b58989a6fff490d674991439ebb69f15e4b63
+>>>>>>> after updating
     permissions:
       contents: write
     secrets:

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -10,11 +10,7 @@ permissions: {}
 
 jobs:
   update:
-<<<<<<< before updating
-    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
-=======
     uses: hugoh/go-tools/.github/workflows/go-template-update.yml@663b58989a6fff490d674991439ebb69f15e4b63
->>>>>>> after updating
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/template-update.yml
+++ b/.github/workflows/template-update.yml
@@ -10,7 +10,11 @@ permissions: {}
 
 jobs:
   update:
+<<<<<<< before updating
     uses: hugoh/go-tools/.github/workflows/go-template-update.yml@f0c60ec582a8ce90080980a4fb79409a0d195491
+=======
+    uses: hugoh/go-tools/.github/workflows/go-template-update.yml@663b58989a6fff490d674991439ebb69f15e4b63
+>>>>>>> after updating
     permissions:
       contents: write
       pull-requests: write

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>hugoh/go-tools"]
+  "extends": ["github>hugoh/go-tools:go-renovaterc"]
 }

--- a/hk.pkl
+++ b/hk.pkl
@@ -16,7 +16,13 @@ local Common = new Group {
     ["conflicts"] = Builtins.check_merge_conflict
     ["trailing-ws"] = Builtins.trailing_whitespace
     ["line-endings"] = Builtins.mixed_line_ending
-    ["newlines"] = Builtins.newlines
+    // .copier-answers.yml is written entirely by copier's own YAML
+    // serializer, not rendered from a template file — it sometimes appends a
+    // trailing blank line on `copier update`, which would otherwise fail this
+    // check on every automated template-update PR
+    ["newlines"] = (Builtins.newlines) {
+      exclude = List(".copier-answers.yml")
+    }
     ["case-conflict"] = Builtins.check_case_conflict
     ["large-files"] = Builtins.check_added_large_files
     ["executables"] = Builtins.check_executables_have_shebangs


### PR DESCRIPTION
Automated `copier update` from [hugoh/go-tools](https://github.com/hugoh/go-tools)@v1.2.2. Auto-merges once hk/goci/release pass — review the diff first if you want to intervene.