### PR TITLE
chore: use full URL for _src_path in copier answers

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,6 +1,6 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
 _commit: v1.2.2
-_src_path: gh:hugoh/go-tools
+_src_path: https://github.com/hugoh/go-tools.git
 codecov_ignore:
 - main.go
 codecov_style: simple


### PR DESCRIPTION
Changes `_src_path` from `gh:hugoh/go-tools` to `https://github.com/hugoh/go-tools.git` so Renovate's git-tags datasource can resolve the template URL (Renovate doesn't understand Copier's `gh:` shorthand).