### PR TITLE
chore: consume hugoh/hk-config's published base.pkl instead of local Common group

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -1,44 +1,28 @@
 amends "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Config.pkl"
 import "package://github.com/jdx/hk/releases/download/v1.49.0/hk@1.49.0#/Builtins.pkl"
-
-local Common = new Group {
-  steps {
-    ["actionlint"] = Builtins.actionlint
-    // hugoh/go-tools' own self-referential workflow pins are rendered by this
-    // template using the raw commit hash with no version comment; excluding
-    // them from pinact keeps that comment-less form stable so copier update's
-    // 3-way merge never has to reconcile a pinact-added comment against the
-    // template's un-commented rendering
-    ["pinact"] = (Builtins.pinact) {
-      check_diff = "pinact run --verify --check --exclude 'hugoh/go-tools.*' {{ files }}"
-      fix = "pinact run --verify --exclude 'hugoh/go-tools.*' {{ files }}"
-    }
-    ["conflicts"] = Builtins.check_merge_conflict
-    // ["trailing-ws"] = Builtins.trailing_whitespace
-    ["line-endings"] = Builtins.mixed_line_ending
-    // .copier-answers.yml is written entirely by copier's own YAML
-    // serializer, not rendered from a template file — it sometimes appends a
-    // trailing blank line on `copier update`, which would otherwise fail this
-    // check on every automated template-update PR
-    ["newlines"] = (Builtins.newlines) {
-      exclude = List(".copier-answers.yml")
-    }
-    ["case-conflict"] = Builtins.check_case_conflict
-    ["large-files"] = Builtins.check_added_large_files
-    ["executables"] = Builtins.check_executables_have_shebangs
-    ["symlinks"] = Builtins.check_symlinks
-    ["gitleaks"] = Builtins.gitleaks
-    ["ghalint"] = Builtins.ghalint_workflow
-    ["markdown"] = Builtins.rumdl
-    ["dprint"] = Builtins.dprint
-    ["zizmor"] = Builtins.zizmor
-    ["typos"] = Builtins.typos
-    ["mise"] = Builtins.mise
-  }
-}
+import "package://github.com/hugoh/hk-config/releases/download/v0.1.0/hk-config@0.1.0#/base.pkl" as Base
 
 local linters = new Mapping<String, Step> {
-  ...Common.steps
+  ...Base.base
+  ["trailing-ws"] = (Base.base["trailing-ws"]) {
+    condition = "false"
+  }
+  // hugoh/go-tools' own self-referential workflow pins are rendered by this
+  // template using the raw commit hash with no version comment; excluding
+  // them from pinact keeps that comment-less form stable so copier update's
+  // 3-way merge never has to reconcile a pinact-added comment against the
+  // template's un-commented rendering
+  ["pinact"] = (Builtins.pinact) {
+    check_diff = "pinact run --verify --check --exclude 'hugoh/go-tools.*' {{ files }}"
+    fix = "pinact run --verify --exclude 'hugoh/go-tools.*' {{ files }}"
+  }
+  // .copier-answers.yml is written entirely by copier's own YAML
+  // serializer, not rendered from a template file — it sometimes appends a
+  // trailing blank line on `copier update`, which would otherwise fail this
+  // check on every automated template-update PR
+  ["newlines"] = (Builtins.newlines) {
+    exclude = List(".copier-answers.yml")
+  }
   ["golangci-lint-config"] = {
     check = "golangci-lint config verify"
   }

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-go = "1.26.4"
+go = "1.26.5"
 "go:github.com/vladopajic/go-test-coverage/v2" = "2.18.8"
 golangci-lint = "2.12.2"
 goreleaser = "2.16.0"


### PR DESCRIPTION
Replaces the local, unmodified 17-step `Common` group in `hk.pkl` with an import of the shared `hugoh/hk-config` package (`base.pkl`), now that it has a tagged release.

Verified locally: `hk validate` passes, and `hk check --plan --json` produces a byte-identical step set/status before and after the change.